### PR TITLE
Disconnect socket if send fails

### DIFF
--- a/src/striemann/metrics.py
+++ b/src/striemann/metrics.py
@@ -125,6 +125,7 @@ class RiemannTransport:
             self._ensure_connected()
             self.transport.send(self._message)
         except Exception as e:
+            self.transport.disconnect()
             logging.error("Failed to flush metrics to riemann", exc_info=True)
         if is_closing:
             self.transport.disconnect()

--- a/src/striemann/tests/test_striemann.py
+++ b/src/striemann/tests/test_striemann.py
@@ -1,6 +1,5 @@
 from expects import expect
 from icdiff_expects import equal
-
 from unittest import mock
 import striemann.metrics
 


### PR DESCRIPTION
Send sometimes fails and never manage to properly reconnect. If we disconnect whenever it fails Striemann will create a new connection on the next flush