### PR TITLE
Reduce memory usage of Range recorder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,4 @@ ENV/
 
 # mypy
 .mypy_cache/
+/.pytest_cache/

--- a/src/striemann/metrics.py
+++ b/src/striemann/metrics.py
@@ -299,20 +299,20 @@ class Range(Recorder):
         current_max = current_summary.get("max")
         current_min = current_summary.get("min")
         current_count = current_summary.get("count", 0)
-        current_mean = current_summary.get("mean", 0)
+        current_total = current_summary.get("total", 0)
 
         new_value = new_metric.value
         new_min = min(current_min, new_value) if current_min is not None else new_value
         new_max = max(current_max, new_value) if current_max is not None else new_value
         new_count = current_count + 1
-        new_mean = current_mean + (new_value - current_mean) / new_count
+        new_total = current_total + new_value
 
         self._metrics_summaries[new_metric.id] = {
             "first": first_metric if first_metric else new_metric,
             "min": new_min,
             "max": new_max,
             "count": new_count,
-            "mean": new_mean,
+            "total": new_total,
         }
 
     def flush(self, transport):
@@ -321,7 +321,7 @@ class Range(Recorder):
 
             self.send(first, summary["min"], transport, ".min")
             self.send(first, summary["max"], transport, ".max")
-            self.send(first, summary["mean"], transport, ".mean")
+            self.send(first, summary["total"] / summary["count"], transport, ".mean")
             self.send(first, summary["count"], transport, ".count")
 
         self._reset()

--- a/src/striemann/tests/test_striemann.py
+++ b/src/striemann/tests/test_striemann.py
@@ -73,7 +73,9 @@ class Test:
         assert stored_data["min"] == 1
         assert stored_data["max"] == 3
         assert stored_data["count"] == 2
-        assert stored_data["mean"] == 2
+        assert (
+            stored_data["total"] == 4,
+        ), 'We call metrics.time("time") twice, once for 1 sec and once for 3 sec so 4 sec in total (see side_effect)'
         first = stored_data["first"]
         assert isinstance(first, striemann.metrics.Metric)
 
@@ -85,7 +87,7 @@ class Test:
         assert stored_data["min"] == 1
         assert stored_data["max"] == 5
         assert stored_data["count"] == 3
-        assert stored_data["mean"] == 3
+        assert stored_data["total"] == 9
         assert stored_data["first"] is first
 
     @mock.patch("timeit.default_timer", side_effect=[0, 1, 0, 3])

--- a/src/striemann/tests/test_striemann.py
+++ b/src/striemann/tests/test_striemann.py
@@ -68,24 +68,25 @@ class Test:
         with metrics.time("time"):
             pass
 
-        stored_data = list(metrics._ranges._metrics.values())[0]
+        [stored_data] = list(metrics._ranges._metrics_summaries.values())
         assert isinstance(stored_data, dict)
         assert stored_data["min"] == 1
         assert stored_data["max"] == 3
         assert stored_data["count"] == 2
         assert stored_data["mean"] == 2
-        assert isinstance(stored_data["first"], striemann.metrics.Metric)
+        first = stored_data["first"]
+        assert isinstance(first, striemann.metrics.Metric)
 
         with metrics.time("time"):
             pass
 
-        stored_data = list(metrics._ranges._metrics.values())[0]
+        [stored_data] = list(metrics._ranges._metrics_summaries.values())
         assert isinstance(stored_data, dict)
         assert stored_data["min"] == 1
         assert stored_data["max"] == 5
         assert stored_data["count"] == 3
         assert stored_data["mean"] == 3
-        assert isinstance(stored_data["first"], striemann.metrics.Metric)
+        assert stored_data["first"] is first
 
     @mock.patch("timeit.default_timer", side_effect=[0, 1, 0, 3])
     def test_timers(self, timer):


### PR DESCRIPTION
Fix OOM issue when a lot of metrics are stored in the Range._metrics[metric.id]. Use a dict computed on the fly instead.

### The problem:
In Availability we use
```python
with metrics.time("..."):
   do_stuff()
```
around every call to redis, which means that we create a time metric tens of thousands of times when we run the job that rebuilds everything in redis.  This uses a lot of memory (because it stores all those metrics in the `Range._metrics` list and then computes the summary at the end when you call `.flush()`.

We've changed it to update the summary on the fly, so it doesn't have to hold all the metrics in memory.